### PR TITLE
Fix wrong card combination when no card selected bug

### DIFF
--- a/CodeForge3.PokerFace.WebApp/Components/Pages/Home.razor
+++ b/CodeForge3.PokerFace.WebApp/Components/Pages/Home.razor
@@ -232,7 +232,7 @@ else if (_evaluatedCombination is not null)
     /// </summary>
     private async Task EvaluateCardsCombination()
     {
-        if (_predictions is null)
+        if (_predictions is null || _predictions.Count == 0)
         {
             Console.WriteLine("Error: predictions empty.");
             return;


### PR DESCRIPTION
The bug of displaying "High Card" as combination, when no cards detected is fixed.

Added check for _predictions list if it is empty.
Now the program displays nothing when no predictions got, instead of displaying the combination of "High Card".