### PR TITLE
Update Home.razor

### DIFF
--- a/CodeForge3.PokerFace.WebApp/Components/Pages/Home.razor
+++ b/CodeForge3.PokerFace.WebApp/Components/Pages/Home.razor
@@ -135,29 +135,29 @@ else if (_evaluatedCombination is not null)
     /// Base64 string used for displaying the uploaded image.
     /// </summary>
     private string? _imagePreview;
-    
+
     /// <summary>
     /// Should the bounding boxes be shown?
     /// </summary>
     private bool _showBoundingBoxes = true;
-    
+
     /// <summary>
     /// The name of the selected model.
     /// </summary>
     private string _selectedModel = PokerFaceConfiguration.CurrentYoloModel;
-    
+
     /// <summary>
     /// The list of available model names.
     /// </summary>
     private IReadOnlyList<string> _availableModels = [];
-    
+
     /// <inheritdoc />
     protected override void OnInitialized()
     {
         _availableModels = PokerAppService.GetModelList();
         base.OnInitialized();
     }
-    
+
     /// <summary>
     /// Selects the image to upload to the server for processing.
     /// </summary>
@@ -168,7 +168,7 @@ else if (_evaluatedCombination is not null)
         _predictions = null;
         _evaluationErrorMessage = null;
         _evaluatedCombination = null;
-        
+
         if (file is not null)
         {
             await using Stream stream = file.OpenReadStream(PokerFaceConfiguration.MaxUploadFileSize);
@@ -182,7 +182,7 @@ else if (_evaluatedCombination is not null)
         {
             _imagePreview = null;
         }
-        
+
         StateHasChanged();
     }
 
@@ -197,18 +197,18 @@ else if (_evaluatedCombination is not null)
         }
 
         _isProcessing = true;
-        
+
         PokerAppService.SelectModel(_selectedModel);
         _predictions = await PokerAppService.PredictCardsAsync(_selectedFile);
-        
+
         await using Stream stream = _selectedFile.OpenReadStream(PokerFaceConfiguration.MaxUploadFileSize);
         using Image<Rgba32> image = await Image.LoadAsync<Rgba32>(stream);
-        
+
         if (_showBoundingBoxes)
         {
             SixColor boxColor = SixColor.Red;
             const float boxThickness = 2f;
-            
+
             image.Mutate(ctx =>
             {
                 foreach (CardPrediction prediction in _predictions)
@@ -217,12 +217,12 @@ else if (_evaluatedCombination is not null)
                 }
             });
         }
-        
+
         using MemoryStream ms = new();
         await image.SaveAsPngAsync(ms);
         string base64 = Convert.ToBase64String(ms.ToArray());
         _imagePreview = $"data:image/png;base64,{base64}";
-        
+
         await EvaluateCardsCombination();
         _isProcessing = false;
     }
@@ -234,7 +234,8 @@ else if (_evaluatedCombination is not null)
     {
         if (_predictions is null || _predictions.Count == 0)
         {
-            Console.WriteLine("Error: predictions empty.");
+            Console.WriteLine("Error: predictions empty. Skip evaluating combination.");
+            _evaluatedCombination = null;
             return;
         }
 


### PR DESCRIPTION
The bug of evaluation results not refreshing when loading a model, that can detect cards on an image, then select a model that cannot detect the cards on that image seems to be solved.